### PR TITLE
Make feature extractions work with both python2 and python 3

### DIFF
--- a/protein_complex_maps/features/ExtractFeatures/Features.py
+++ b/protein_complex_maps/features/ExtractFeatures/Features.py
@@ -1,10 +1,10 @@
 #! /usr/bin/env python
-
+from __future__ import print_function
 import numpy as np
 import pandas as pd
 import itertools as it
 
-from functions import features, resampling
+from .functions import features, resampling
 
 
 class Elut():
@@ -87,7 +87,7 @@ class Elut():
         len_before = len(self.df)
         self.df = self.df[ self.df["sum"] >= thresh ]
         self.df.drop("sum",axis=1,inplace=True)
-        print "Dropped {} rows".format(len_before - len(self.df))
+        print("Dropped {} rows".format(len_before - len(self.df)))
         self.is_thresholded = True
         
     def make_tidy(self,just_return=False):
@@ -107,7 +107,7 @@ class Elut():
     def _get_info(self):
         '''Output simple info on the stored elution profiles'''
         if self.df is None:
-            print "No loaded data"
+            print("No loaded data")
             return
         
         self.row_sums = self.df.sum(axis=1)
@@ -203,7 +203,7 @@ class ElutFeatures(Elut,features.FeatureFunctions,resampling.FeatureResampling):
             self._analysis["normalize"] = 'norm' + "".join(normalize)
         
         if feature in ["jensen_shannon","kullback_leibler"]:
-            print "Adding pseudocounts and re-normalizing for JS or KL divergence"
+            print("Adding pseudocounts and re-normalizing for JS or KL divergence")
             self.df = self.df + 1
             self.normalize(by='row_max')
             

--- a/protein_complex_maps/features/ExtractFeatures/canned_scripts/average_features.py
+++ b/protein_complex_maps/features/ExtractFeatures/canned_scripts/average_features.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-
+from __future__ import print_function
 import argparse
 import functools
 import numpy as np
@@ -22,7 +22,7 @@ if __name__ == '__main__':
     files_processed = []
     is_first = True
     for ind,f in enumerate(args.infiles):
-        print "Reading in {}".format(f)
+        print("Reading in {}".format(f))
         if args.in_pickle:
             df = pd.read_pickle(f)
             assert len(df.columns) == 3, "Pickled infiles should have 3 columns: ID1, ID2, feature"
@@ -66,7 +66,7 @@ if __name__ == '__main__':
                 "min": functools.partial( merged.min )}
     
     for avg in args.average_type:
-        print "Performing {}".format(avg)
+        print("Performing {}".format(avg))
         merged["{}_{}".format(avg,feature)] = avgFuncD[avg](axis=1)
         
     if args.retain_columns == False:

--- a/protein_complex_maps/features/ExtractFeatures/canned_scripts/print_elution_info.py
+++ b/protein_complex_maps/features/ExtractFeatures/canned_scripts/print_elution_info.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-
+from __future__ import print_function
 import argparse
 from protein_complex_maps.features.ExtractFeatures.Features import Elut
 
@@ -10,16 +10,16 @@ args = parser.parse_args()
 def pretty_dict(D,indent_width=0):
     for key,val in D.iteritems():
         if type(val) is dict:
-            print ' '*indent_width + key
+            print(' '*indent_width + key)
             pretty_dict(val,indent_width*2)
         else:
-            print ' '*indent_width + "\t".join([key,str(val)])
+            print(' '*indent_width + "\t".join([key,str(val)]))
  
 if __name__ == '__main__':
     for f in args.infiles:
         e = Elut()
         e.load(f)
-        print f
+        print(f)
         pretty_dict(e.info,4)
         if len(args.infiles) > 1:
             print

--- a/protein_complex_maps/features/ExtractFeatures/functions/resampling.py
+++ b/protein_complex_maps/features/ExtractFeatures/functions/resampling.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import numpy as np
 
 class FeatureResampling:
@@ -7,10 +8,10 @@ class FeatureResampling:
     def _poisson_noise(self,df,rep=None):
         '''Return dataframe with poisson noise added'''
         ## bjl: Not sure why we just add, should we randomly subtract as well?? ##
-        if rep: print "rep {}".format(rep)
+        if rep: print("rep {}".format(rep))
         return df + np.random.poisson(df)
         
     def _bootstrap(self,df,rep=None):
         '''Sample columns with replacement, returning df of same shape'''
-        if rep: print "rep {}".format(rep)
+        if rep: print("rep {}".format(rep))
         return df.sample(df.shape[1], replace=True, axis=1)


### PR DESCRIPTION
Now we can calculate features with either python2 or python3. Avoids having to set up a python2 environment for new users