### PR TITLE
Fix build matrix

### DIFF
--- a/protein_complex_maps/features/ExtractFeatures/Features.py
+++ b/protein_complex_maps/features/ExtractFeatures/Features.py
@@ -1,10 +1,10 @@
 #! /usr/bin/env python
-
+from __future__ import print_function
 import numpy as np
 import pandas as pd
 import itertools as it
 
-from functions import features, resampling
+from .functions import features, resampling
 
 
 class Elut():
@@ -87,7 +87,7 @@ class Elut():
         len_before = len(self.df)
         self.df = self.df[ self.df["sum"] >= thresh ]
         self.df.drop("sum",axis=1,inplace=True)
-        print "Dropped {} rows".format(len_before - len(self.df))
+        print("Dropped {} rows".format(len_before - len(self.df)))
         self.is_thresholded = True
         
     def make_tidy(self,just_return=False):
@@ -107,7 +107,7 @@ class Elut():
     def _get_info(self):
         '''Output simple info on the stored elution profiles'''
         if self.df is None:
-            print "No loaded data"
+            print("No loaded data")
             return
         
         self.row_sums = self.df.sum(axis=1)
@@ -203,7 +203,7 @@ class ElutFeatures(Elut,features.FeatureFunctions,resampling.FeatureResampling):
             self._analysis["normalize"] = 'norm' + "".join(normalize)
         
         if feature in ["jensen_shannon","kullback_leibler"]:
-            print "Adding pseudocounts and re-normalizing for JS or KL divergence"
+            print("Adding pseudocounts and re-normalizing for JS or KL divergence")
             self.df = self.df + 1
             self.normalize(by='row_max')
             

--- a/protein_complex_maps/features/ExtractFeatures/canned_scripts/average_features.py
+++ b/protein_complex_maps/features/ExtractFeatures/canned_scripts/average_features.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-
+from __future__ import print_function
 import argparse
 import functools
 import numpy as np
@@ -22,7 +22,7 @@ if __name__ == '__main__':
     files_processed = []
     is_first = True
     for ind,f in enumerate(args.infiles):
-        print "Reading in {}".format(f)
+        print("Reading in {}".format(f))
         if args.in_pickle:
             df = pd.read_pickle(f)
             assert len(df.columns) == 3, "Pickled infiles should have 3 columns: ID1, ID2, feature"
@@ -66,7 +66,7 @@ if __name__ == '__main__':
                 "min": functools.partial( merged.min )}
     
     for avg in args.average_type:
-        print "Performing {}".format(avg)
+        print("Performing {}".format(avg))
         merged["{}_{}".format(avg,feature)] = avgFuncD[avg](axis=1)
         
     if args.retain_columns == False:

--- a/protein_complex_maps/features/ExtractFeatures/canned_scripts/print_elution_info.py
+++ b/protein_complex_maps/features/ExtractFeatures/canned_scripts/print_elution_info.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-
+from __future__ import print_function
 import argparse
 from protein_complex_maps.features.ExtractFeatures.Features import Elut
 
@@ -10,16 +10,16 @@ args = parser.parse_args()
 def pretty_dict(D,indent_width=0):
     for key,val in D.iteritems():
         if type(val) is dict:
-            print ' '*indent_width + key
+            print(' '*indent_width + key)
             pretty_dict(val,indent_width*2)
         else:
-            print ' '*indent_width + "\t".join([key,str(val)])
+            print(' '*indent_width + "\t".join([key,str(val)]))
  
 if __name__ == '__main__':
     for f in args.infiles:
         e = Elut()
         e.load(f)
-        print f
+        print(f)
         pretty_dict(e.info,4)
         if len(args.infiles) > 1:
             print

--- a/protein_complex_maps/features/ExtractFeatures/functions/resampling.py
+++ b/protein_complex_maps/features/ExtractFeatures/functions/resampling.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import numpy as np
 
 class FeatureResampling:
@@ -7,10 +8,10 @@ class FeatureResampling:
     def _poisson_noise(self,df,rep=None):
         '''Return dataframe with poisson noise added'''
         ## bjl: Not sure why we just add, should we randomly subtract as well?? ##
-        if rep: print "rep {}".format(rep)
+        if rep: print("rep {}".format(rep))
         return df + np.random.poisson(df)
         
     def _bootstrap(self,df,rep=None):
         '''Sample columns with replacement, returning df of same shape'''
-        if rep: print "rep {}".format(rep)
+        if rep: print("rep {}".format(rep))
         return df.sample(df.shape[1], replace=True, axis=1)

--- a/protein_complex_maps/features/alphabetize_pairs.py
+++ b/protein_complex_maps/features/alphabetize_pairs.py
@@ -35,34 +35,36 @@ def main():
                                     help="Filename of comma separated output")
     parser.add_argument("--sep", action = "store",dest='sep' , default=' ', required=False)
     parser.add_argument("--columns", nargs='+', action="store", type=int, dest="columns2alphabetize", required=False, default=[0,1], 
-                                    help="List of columns to alphabetize, default = 0,1")
+                                    help="List of columns (positions) to alphabetize, default = 0,1")
+    parser.add_argument("--header", action="store", dest="header", required=False, default=True, 
+                                    help="Do input pairs files have headers?")
+
     args = parser.parse_args()
-    df = pd.read_table(args.df, sep=args.sep, header=None)
+
+    if args.header == True:
+        df = pd.read_table(args.df, sep=args.sep, header=0)
+    if args.header == False:
+        df = pd.read_table(args.df, sep=args.sep, header=None)
+
+
     print(df)
 
 
-    #sorted is faster than np.sort
-
-    #df[df.columns[args.columns2alphabetize]] = df[df.columns[args.columns2alphabetize]].apply(sorted,axis=1)
- 
-    #For troubleshooting speed of the apply function
-    #tqdm.pandas(desc="Progress of alphabetization")
-
-    #Saving as intermediate variable is necessary for large dataframes (at least over 9 million rows)
-    #For troubleshooting, progress_apply gives a progress bar, but needs tqdm package
-    #x =  df[df.columns[args.columns2alphabetize]].progress_apply(sorted,axis=1)
     df = alphabetize_df(df, args.columns2alphabetize)
-    #print(df)
     if args.sep == '\\t':
            args.sep = '\t'
   
-
-    df.to_csv(args.outfile, header=False, index=False, sep=args.sep)
+    if args.header == True:
+        df.to_csv(args.outfile, header=True, index=False, sep=args.sep)
+    if args.header == False:
+        df.to_csv(args.outfile, header=False, index=False, sep=args.sep)
 
 
 def alphabetize_df(df, columns2alphabetize):
+
     intermediate_df =  df[df.columns[columns2alphabetize]].apply(sorted,axis=1)
     df[df.columns[columns2alphabetize]] = intermediate_df
+   
     return df
 
 

--- a/protein_complex_maps/features/alphabetize_pairs.py
+++ b/protein_complex_maps/features/alphabetize_pairs.py
@@ -63,6 +63,8 @@ def main():
 def alphabetize_df(df, columns2alphabetize):
 
     intermediate_df =  df[df.columns[columns2alphabetize]].apply(sorted,axis=1)
+    print(intermediate_df)
+
     df[df.columns[columns2alphabetize]] = intermediate_df
    
     return df

--- a/protein_complex_maps/features/build_feature_matrix.py
+++ b/protein_complex_maps/features/build_feature_matrix.py
@@ -10,16 +10,20 @@ import os.path
 
 def build_matrix():
 
-    parser = argparse.ArgumentParser(description="Builds feature matrix by concatenating pairs files")
-    parser.add_argument("--input_pairs_files", action="store", dest="pairs_files", nargs='+', required=True, 
-                                    help="Filenames of pairs files, format: id1 id2 value")
+    parser = argparse.ArgumentParser(description="Builds feature matrix by concatenating pairs files (format: ID1 ID2 value")
+    parser.add_argument("--input_pairs_files", action="store", dest="pairs_files", nargs='+', required=False, 
+                                    help="Filenames of pairs files, space separated string")
+
+    parser.add_argument("--input_pairs_list", action="store", dest="pairs_file_list", required=False, 
+                                    help="File of pairs filenames, one per line")
+
     parser.add_argument("--sep", action="store", dest="sep", required=True, 
                                     help="Separator for input files")
 
     parser.add_argument("--prev_feature_matrix", action="store", nargs='?', dest='dfall', required=False)
     parser.add_argument("--store_interval", action="store", dest="interval", type=int, required=False, default=None, 
                                     help="If provided, stores an intermediate features matrix every x files joined")
-    parser.add_argument("--output_file", action="store", dest="out_filename", required=True, default=None, 
+    parser.add_argument("--output_file", action="store", dest="out_filename", required=True, 
                                     help="Filename of output file")
     parser.add_argument("--header", action="store", dest="header", required=False, default=True, 
                                     help="Do input pairs files have headers?")
@@ -28,21 +32,35 @@ def build_matrix():
     
     dfall = args.dfall
 
+    if not args.pairs_files:
+         if not args.pairs_file_list:
+            print("either --input_pairs or --input_pairs_file required")
+            return()
 
     print(dfall)
     if not dfall:
         dfall = pd.DataFrame(columns=['ID'])
      
     else:
-        dfall = pd.read_table(dfall, sep=",")
+        dfall = pd.read_csv(dfall)
         print(dfall)
         
+    print("interval", args.interval) 
+
     #kdrew: read in pairs files
     dfall = dfall.set_index(['ID'])
     out_columns = []
 
 
-    for i, filename in enumerate(args.pairs_files):
+    if args.pairs_files:
+           pairs_files = args.pairs_files
+    if args.pairs_file_list:
+           pairs_files = pd.read_csv(args.pairs_file_list, header = None, names = ["filenames"])["filenames"].tolist()
+
+
+
+    print(pairs_files)
+    for i, filename in enumerate(pairs_files):
         print(i, filename)
         value_name = '.'.join(os.path.basename(filename).split('.')[:-2])
         out_columns.append(value_name)
@@ -76,7 +94,7 @@ def build_matrix():
         if args.interval: 
             if i % args.interval == 0:
                 if i > 0:
-                    int_out_filename = args.out_filename +  ".interval_" + str(i) 
+                    int_out_filename = args.out_filename +  ".intermediate_" + str(i) 
                     dfall.to_csv(int_out_filename)
 
            

--- a/protein_complex_maps/features/build_feature_matrix.py
+++ b/protein_complex_maps/features/build_feature_matrix.py
@@ -21,10 +21,12 @@ def build_matrix():
                                     help="If provided, stores an intermediate features matrix every x files joined")
     parser.add_argument("--output_file", action="store", dest="out_filename", required=True, default=None, 
                                     help="Filename of output file")
+    parser.add_argument("--header", action="store", dest="header", required=False, default=True, 
+                                    help="Do input pairs files have headers?")
+
     args = parser.parse_args()
     
     dfall = args.dfall
-
 
 
     print(dfall)
@@ -32,16 +34,10 @@ def build_matrix():
         dfall = pd.DataFrame(columns=['ID'])
      
     else:
-   	 dfall = pd.read_table(dfall, sep=",")
-         print(dfall)
+        dfall = pd.read_table(dfall, sep=",")
+        print(dfall)
         
-         #dfall['pairset'] = map(frozenset, zip( dfall['ID1'].values, dfall['ID2'].values ))
-         #a['IDHash'] = a.ID.apply(lambda r: tuple(sorted(r.iteritems())))
-         #b['IDHash'] = b.ID.apply(lambda r: tuple(sorted(r.iteritems())))
-         #print("dfall index set")
-    #Claire: haven't checked this, but allow features to be added onto existing feature matrix. 
     #kdrew: read in pairs files
-    #dfall = pd.DataFrame(columns=['pairset'])
     dfall = dfall.set_index(['ID'])
     out_columns = []
 
@@ -50,7 +46,13 @@ def build_matrix():
         print(i, filename)
         value_name = '.'.join(os.path.basename(filename).split('.')[:-2])
         out_columns.append(value_name)
-        df = pd.read_csv(filename, delimiter=args.sep, header=None, names=['A', 'B', value_name])
+     
+        if args.header == True:
+            df = pd.read_csv(filename, delimiter=args.sep, header=0, names=['A', 'B', value_name])
+        elif args.header == False:
+            df = pd.read_csv(filename, delimiter=args.sep, header=None, names=['A', 'B', value_name])
+
+
         print(df)
         df['ID']=df.apply(lambda x:'%s %s' % (x['A'],x['B']),axis=1)
         print("new column made")
@@ -59,45 +61,28 @@ def build_matrix():
         df = df_intermediate
         print(df)
 
-        #df.columns = ['ID',value_name])
-
-        #print(filename)
         if value_name in dfall.columns:
             dfall  = dfall.drop(value_name, 1)
         
-        #kdrew: create frozenset column with id1 and id2
-        #df['pairset'] = map(frozenset, zip( df['id1'].values, df['id2'].values ))
-        #print(df)
-        #claire get rid of ID columns
-        #df = df[['pairset', value_name]]
         df = df.set_index(['ID'])
         print(df.shape)
         dfall_intermediate = dfall.join(df, how='outer', rsuffix=('_%s' % (i) ))
-        #dfall_intermediate = dfall.join(df, how='outer', rsuffix=('_%s' % (i) ))
         dfall = None
         dfall = dfall_intermediate
         dfall_intermediate = None
         df = None
- 
-        if i % args.interval == 0:
-             int_out_filename = "interval_" + str(i) + "_" + args.out_filename
-             dfall.to_csv(int_out_filename)
+  
+        # Save an intermediate file for long running joins
+        if args.interval: 
+            if i % args.interval == 0:
+                if i > 0:
+                    int_out_filename = args.out_filename +  ".interval_" + str(i) 
+                    dfall.to_csv(int_out_filename)
 
            
-        #print(dfall)
-        #print(df)
         print(dfall.shape)
-        #kdrew: outer merge dfs on frozenset column
-        #dfall = dfall.merge(df, how='outer', on='pairset', suffixes=('', '_%s' % (i) ))
 
     dfall = dfall.reset_index()
-    #dfall['ID1'] = [list(x)[0] for x in dfall['pairset'].values]
-    #dfall['ID2'] = [list(x)[1] for x in dfall['pairset'].values]
-
-    #kdrew: prepend global id columns to out vector
-    #out_columns = ['ID1','ID2'] + out_columns
-
-    #dfall = dfall.fillna(0.0)
 
     #kdrew: write to file 
     dfall.to_csv(args.out_filename, index=False)


### PR DESCRIPTION
Doesn't change command line

Fixes that there was no option for files that have a header. Since extract_features.py makes files with a header, this option needed to be added. 

Now checks to see if the arguments to store intermediate files is there before trying to write files.



